### PR TITLE
Angular compilation timeout increased

### DIFF
--- a/TheraLang.Web/Startup.cs
+++ b/TheraLang.Web/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.SpaServices.AngularCli;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System;
 using TheraLang.BLL.Infrastructure;
 using TheraLang.BLL.Interfaces;
 using TheraLang.BLL.Services;
@@ -109,6 +110,7 @@ namespace TheraLang.Web
                 // see https://go.microsoft.com/fwlink/?linkid=864501
 
                 spa.Options.SourcePath = "ClientApp";
+                spa.Options.StartupTimeout = new TimeSpan(0, 1, 30);
 
                 if (env.IsDevelopment())
                 {


### PR DESCRIPTION
When we run our app we get the following exception:
System.TimeoutException: The Angular CLI process did not start listening for requests within the timeout period of 50 seconds. Check the log output for error information.

*increased to 90 seconds